### PR TITLE
Write cached images in binary format. Fixes #2.

### DIFF
--- a/addon/routes/notification.py
+++ b/addon/routes/notification.py
@@ -54,7 +54,7 @@ def on_notification_posted(data):
                                  hashlib.md5(small_icon_data).hexdigest())
 
     if not os.path.exists(icon_path):
-        with open(icon_path, 'w') as f:
+        with open(icon_path, 'wb') as f:
             f.write(icon.decode('base64'))
 
     addon = xbmcaddon.Addon()


### PR DESCRIPTION
Change open mode form 'w' to 'wb'. See https://github.com/linuxwhatelse/service.linuxwhatelse.notify/issues/2.